### PR TITLE
Fix a couple issues with the npm page

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A library to create and customize simple dialog windows for Pebble watchapps.
 
-![Aplite](/images/aplite.png) ![Basalt](/images/basalt.png) ![Chalk](/images/chalk.png)
+![Aplite](images/aplite.png) ![Basalt](images/basalt.png) ![Chalk](images/chalk.png)
 
 ## Behavior
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
     "pebble-ui",
     "pebble-window"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cat-haines/pebble-ui-dialog-window.git"
+  },
   "dependencies": {},
   "pebble": {
     "projectType": "package",


### PR DESCRIPTION
Couple of issues with the npm page for this package: https://www.npmjs.com/package/pebble-ui-dialog-window
1. Images are broken
2. Doesn't link back to the repo
